### PR TITLE
Use python3 typehints in description

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -14,7 +14,6 @@
 
 import os
 import six
-import sys
 import time
 
 import autoapi
@@ -47,6 +46,7 @@ catkin_package = catkin_pkg.package.parse_package(os.path.join(catkin_dir, catki
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.autodoc',
     'autoapi.extension',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
@@ -74,6 +74,11 @@ source_suffix = '.rst'
 # The master toctree document.
 master_doc = 'index'
 
+# autodoc.typehints
+autodoc_typehints = 'description'
+autodoc_typehints_description_target = 'all'
+
+# autoapi
 autoapi_type = 'python'
 autoapi_dirs = [os.path.abspath(os.path.join(catkin_dir, 'src'))]
 

--- a/conf.py
+++ b/conf.py
@@ -14,6 +14,7 @@
 
 import os
 import six
+import sys
 import time
 
 import autoapi
@@ -346,7 +347,8 @@ texinfo_documents = [
 intersphinx_mapping = {
     'sphinx': ('http://www.sphinx-doc.org/en/master/', None),
 }
-if six.PY3:
-    intersphinx_mapping['python'] = ('https://docs.python.org/3.7/', None)
+if not six.PY2:
+    python_version = '{}.{}'.format(sys.version_info.major, sys.version_info.minor)
+    intersphinx_mapping['python'] = ('https://docs.python.org/{}/'.format(python_version), None)
 else:
     intersphinx_mapping['python'] = ('https://docs.python.org/2.7/', None)


### PR DESCRIPTION
This use the typehints in the description. So the signature will have the typehints removed. As with many arguments, it becomes very long.

There is no need for `:type` in the docstrings anymore.